### PR TITLE
feat(landlord): add post edit screen & update manage-card edit redirect

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -18,6 +18,7 @@ export default function MainLayout() {
 
       <Stack.Screen name="post/new" options={{ headerShown: false }} />
       <Stack.Screen name="post/[id]" options={{ headerShown: false }} />
+      <Stack.Screen name="post/[id]/edit" options={{ headerShown: false }} />
       <Stack.Screen name="profile/[id]" options={{ headerShown: false }} />
     </Stack>
   );

--- a/app/(app)/post/[id]/edit.tsx
+++ b/app/(app)/post/[id]/edit.tsx
@@ -1,0 +1,8 @@
+// screens
+import { PostEditView } from '@/screens/post/form/view';
+
+// ----------------------------------------------------------------------
+
+export default function PostEditScreen() {
+  return <PostEditView />;
+}

--- a/screens/manage/manage-card.tsx
+++ b/screens/manage/manage-card.tsx
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+// @expo
+import { router } from 'expo-router';
 // styles
 import Colors from '@/styles/constants/Colors';
 import Fonts from '@/styles/constants/Fonts';
@@ -30,7 +32,7 @@ export default function ManageCard({ item }: Props) {
   const { id, title, imageUrl } = item;
 
   const handleEdit = useCallback(() => {
-    console.log('Post: ', id);
+    router.push(`/post/${id}/edit`);
   }, [id]);
 
   const handleDelete = () => {

--- a/screens/post/form/view/form-edit-view.tsx
+++ b/screens/post/form/view/form-edit-view.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+// @expo
+import { router, useLocalSearchParams } from 'expo-router';
+// utils
+import axios, { API_ENDPOINTS } from '@/utils/axios';
+// types
+import { PostResponse } from '@/types/posts';
+// components
+import SpinnerOverlay from '@/components/spinner-overlay';
+//
+import PostFormView, { FormValuesProps } from './form-view';
+
+// ----------------------------------------------------------------------
+
+export default function PostEditView() {
+  const { id } = useLocalSearchParams();
+
+  const [data, setData] = useState<FormValuesProps>();
+
+  const loading = !data;
+
+  const getData = useCallback(async () => {
+    try {
+      const postResponse = await axios.get(API_ENDPOINTS.post.get(id as string));
+
+      const post: PostResponse = postResponse.data;
+
+      const _data: FormValuesProps = {
+        title: post.title,
+        price: post.price,
+        description: post.description,
+        uploads: post.uploads.map((_) => ({
+          uri: _.imgUrl,
+          name: _.imgUrl.split('/').pop() || 'image.jpeg',
+          type: 'image',
+        })),
+      };
+
+      setData(_data);
+    } catch (error) {
+      router.back();
+      console.error(error);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    getData();
+  }, [getData]);
+
+  if (!data) {
+    return <SpinnerOverlay state={loading} />;
+  }
+
+  return <PostFormView currentItem={data} />;
+}

--- a/screens/post/form/view/index.ts
+++ b/screens/post/form/view/index.ts
@@ -1,1 +1,2 @@
+export { default as PostEditView } from './form-edit-view';
 export { default as PostFormView } from './form-view';


### PR DESCRIPTION
### Resolves Sprint:

<!--- Link to sprint ticket --->
<!--- e.g. "[TICKET-001](https://kanban.example.com/tickets/TICKET-001)" --->

N/A

### This PR...

<!--- Short description of the overall change --->
<!--- e.g. "Adds hero section on homescreen" --->

Adds PostEdit screen for Landlord users.

### Changes:

<!--- Bullet points of changes made --->

- update Tab layout routes for PostEdit screen
- update ManageCard to redirect edit button

### Notes:

<!--- Any extra notes --->
<!--- e.g. how to test, links to relevant GitHub actions, follow-up tasks, etc. --->

N/A

### Screenshots:

<!--- Screenshots if relevant --->

<img width="225" height="500" alt="Screenshot_1756883655" src="https://github.com/user-attachments/assets/8e45453a-2d9c-46b8-8c2e-6a070a386ded" />

---

#### Check list:

- [ ] Sprint ticket met/completed
- [ ] Visual design aligned with design system
- [ ] A11y pass
- [ ] Built and run locally across all platforms, ensure no build or runtime errors/warnings
- [ ] Cross-browser/device testing
- [ ] No console errors
- [ ] Unit/functional tests are written; Or a manual test is planned
- [ ] Storybook component added and documented
- [ ] Config added/updated
- [ ] Updated `README.md`/docs to reflect changes
- [ ] Updated `.env.sample`
