### PR TITLE
feat: add settings screen & sections

### DIFF
--- a/app/(app)/(tabs)/settings.tsx
+++ b/app/(app)/(tabs)/settings.tsx
@@ -1,31 +1,8 @@
-import { useCallback } from 'react';
-import { Pressable } from 'react-native';
-// @expo
-import { router } from 'expo-router';
-// auth
-import { useAuthContext } from '@/auth/hooks';
-// components
-import { ThemedText, ThemedView } from '@/components/themed-native';
+// screens
+import { SettingsView } from '@/screens/settings/main/view';
 
 // ----------------------------------------------------------------------
 
 export default function SettingsScreen() {
-  const { logout } = useAuthContext();
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await logout();
-      router.replace('/login');
-    } catch (error) {
-      console.error(error);
-    }
-  }, [logout]);
-
-  return (
-    <ThemedView className="flex-1 items-center justify-center">
-      <Pressable onPress={handleLogout}>
-        <ThemedText className="text-4xl">Settings</ThemedText>
-      </Pressable>
-    </ThemedView>
-  );
+  return <SettingsView />;
 }

--- a/screens/_components/index.ts
+++ b/screens/_components/index.ts
@@ -1,4 +1,5 @@
 export { default as FooterActions } from './footer-actions';
 export { default as PostCard } from './post-card';
+export { default as SettingsHeader } from './settings-header';
 export { default as UserBanner } from './user-banner';
 export { default as UserCard } from './user-card';

--- a/screens/_components/settings-header.tsx
+++ b/screens/_components/settings-header.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export default function SettingsHeader({ title, actionLeft, actionRight }: Props) {
   return (
-    <ThemedView style={[styles.container, styles.fixed]}>
+    <ThemedView style={styles.container}>
       <View style={styles.actionLeft}>{actionLeft}</View>
 
       <View style={styles.label}>
@@ -36,12 +36,6 @@ const styles = StyleSheet.create({
     position: 'relative',
     flexDirection: 'row',
     justifyContent: 'space-between',
-  },
-  fixed: {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
   },
   label: {
     padding: 16,

--- a/screens/_components/settings-header.tsx
+++ b/screens/_components/settings-header.tsx
@@ -1,0 +1,79 @@
+import { StyleSheet, View } from 'react-native';
+// styles
+import Fonts from '@/styles/constants/Fonts';
+// components
+import { ThemedText, ThemedView } from '@/components/themed-native';
+
+// ----------------------------------------------------------------------
+
+type Props = {
+  title: string;
+  actionLeft?: React.ReactNode;
+  actionRight?: React.ReactNode;
+};
+
+// ----------------------------------------------------------------------
+
+export default function SettingsHeader({ title, actionLeft, actionRight }: Props) {
+  return (
+    <ThemedView style={[styles.container, styles.fixed]}>
+      <View style={styles.actionLeft}>{actionLeft}</View>
+
+      <View style={styles.label}>
+        <ThemedText numberOfLines={1} style={styles.title}>
+          {title}
+        </ThemedText>
+      </View>
+
+      <View style={styles.actionRight}>{actionRight}</View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    minHeight: 56,
+    position: 'relative',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  fixed: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  label: {
+    padding: 16,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1,
+  },
+  title: {
+    ...Fonts[500],
+    fontSize: 18,
+    maxWidth: '50%',
+  },
+  actionLeft: {
+    flex: 1,
+    paddingLeft: 16,
+    paddingVertical: 4,
+    minHeight: 24,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    zIndex: 2,
+  },
+  actionRight: {
+    flex: 1,
+    paddingRight: 16,
+    paddingVertical: 4,
+    minHeight: 24,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    zIndex: 2,
+  },
+});

--- a/screens/login/login-input-field.tsx
+++ b/screens/login/login-input-field.tsx
@@ -24,7 +24,7 @@ export default function LoginInputField({ name, label, secureTextEntry = false }
       name={name}
       control={control}
       render={({ field }) => (
-        <View className="relative items-center justify-center">
+        <View style={styles.container}>
           <TextInput
             {...field}
             value={field.value}
@@ -48,6 +48,11 @@ export default function LoginInputField({ name, label, secureTextEntry = false }
 }
 
 const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   input: {
     width: '60%',
     height: 48,

--- a/screens/settings/main/config-route.tsx
+++ b/screens/settings/main/config-route.tsx
@@ -1,0 +1,60 @@
+// components
+import useCustomAlert from '@/components/custom-alert';
+
+// ----------------------------------------------------------------------
+
+export type SettingsRouteConfig = {
+  title: string;
+  data: SettingsRouteDataType[];
+};
+
+export type SettingsRouteDataType = {
+  label: string;
+  onClick: VoidFunction;
+  isExternal?: boolean;
+};
+
+// ----------------------------------------------------------------------
+
+export const SettingsConfig = (): SettingsRouteConfig[] => {
+  const { alert } = useCustomAlert();
+
+  return [
+    {
+      title: 'Account information',
+      data: [
+        {
+          label: 'Edit profile',
+          onClick: () => alert({ title: 'Oops!', message: 'This page is not yet available.' }),
+        },
+        {
+          label: 'Account settings',
+          onClick: () => alert({ title: 'Oops!', message: 'This page is not yet available.' }),
+        },
+        {
+          label: 'Privacy',
+          onClick: () => alert({ title: 'Oops!', message: 'This page is not yet available.' }),
+        },
+      ],
+    },
+    {
+      title: 'Support',
+      data: [
+        {
+          label: 'Feedback',
+          onClick: () => alert({ title: 'Oops!', message: 'This page is not yet available.' }),
+          isExternal: true,
+        },
+        {
+          label: 'Terms & privacy',
+          onClick: () => alert({ title: 'Oops!', message: 'This page is not yet available.' }),
+          isExternal: true,
+        },
+        {
+          label: 'About',
+          onClick: () => alert({ title: 'Oops!', message: 'This page is not yet available.' }),
+        },
+      ],
+    },
+  ];
+};

--- a/screens/settings/main/settings-list.tsx
+++ b/screens/settings/main/settings-list.tsx
@@ -1,0 +1,78 @@
+import { SectionList, StyleSheet, TouchableOpacity, View } from 'react-native';
+// hooks
+import { useColorScheme } from '@/hooks/use-color-scheme';
+// styles
+import Colors from '@/styles/constants/Colors';
+import Fonts from '@/styles/constants/Fonts';
+// components
+import { ThemedText } from '@/components/themed-native';
+// assets
+import { IconArrow } from '@/assets/icons';
+//
+import { SettingsConfig } from './config-route';
+import SettingsLogout from './settings-logout';
+
+// ----------------------------------------------------------------------
+
+export default function SettingsList() {
+  const colorScheme = useColorScheme() ?? 'light';
+
+  const data = SettingsConfig();
+
+  return (
+    <SectionList
+      sections={data}
+      keyExtractor={(item) => item.label}
+      contentContainerStyle={styles.container}
+      //
+      renderItem={({ item, index, section }) => {
+        const isLast = index === section.data.length - 1;
+
+        return (
+          <TouchableOpacity
+            onPress={item.onClick}
+            style={[styles.item, isLast && { marginBottom: 32 }]}
+          >
+            <ThemedText numberOfLines={1} style={styles.title}>
+              {item.label}
+            </ThemedText>
+
+            <IconArrow
+              variant="outline"
+              direction={item.isExternal ? 'right-up' : 'right'}
+              size={24}
+              color={Colors[colorScheme].text}
+            />
+          </TouchableOpacity>
+        );
+      }}
+      renderSectionHeader={({ section }) => (
+        <ThemedText style={styles.header}>{section.title}</ThemedText>
+      )}
+      //
+      ListFooterComponent={<SettingsLogout />}
+      ItemSeparatorComponent={() => <View style={{ height: 16 }} />}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingTop: 24,
+    paddingHorizontal: 16,
+  },
+  header: {
+    marginBottom: 16,
+    fontSize: 14,
+    color: Colors.grey[600],
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    ...Fonts[600],
+    flex: 1,
+    fontSize: 18,
+  },
+});

--- a/screens/settings/main/settings-logout.tsx
+++ b/screens/settings/main/settings-logout.tsx
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+// @expo
+import { router } from 'expo-router';
+// hooks
+import { useAuthContext } from '@/auth/hooks';
+// styles
+import Colors from '@/styles/constants/Colors';
+import Fonts from '@/styles/constants/Fonts';
+// components
+import useCustomAlert from '@/components/custom-alert';
+import { ThemedText } from '@/components/themed-native';
+
+// ----------------------------------------------------------------------
+
+export default function SettingsLogout() {
+  const { logout } = useAuthContext();
+
+  const { alert } = useCustomAlert();
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await logout();
+      router.replace('/login');
+    } catch (error) {
+      console.error(error);
+      alert({ title: 'Unable to logout!', message: 'Please check your network and try again.' });
+    }
+  }, [logout, alert]);
+
+  return (
+    <View style={styles.container}>
+      <ThemedText style={styles.header}>Actions</ThemedText>
+
+      <TouchableOpacity onPress={handleLogout} style={styles.item}>
+        <ThemedText numberOfLines={1} style={styles.title}>
+          Log out
+        </ThemedText>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingBottom: 24 + 76,
+  },
+  header: {
+    marginBottom: 16,
+    fontSize: 14,
+    color: Colors.grey[600],
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    ...Fonts[600],
+    flex: 1,
+    fontSize: 18,
+  },
+});

--- a/screens/settings/main/view/index.ts
+++ b/screens/settings/main/view/index.ts
@@ -1,0 +1,1 @@
+export { default as SettingsView } from './settings-view';

--- a/screens/settings/main/view/settings-view.tsx
+++ b/screens/settings/main/view/settings-view.tsx
@@ -1,0 +1,17 @@
+import { View } from 'react-native';
+// components
+import { SettingsHeader } from '@/screens/_components';
+//
+import SettingsList from '../settings-list';
+
+// ----------------------------------------------------------------------
+
+export default function SettingsView() {
+  return (
+    <View className="flex-1">
+      <SettingsHeader title="Settings" />
+
+      <SettingsList />
+    </View>
+  );
+}


### PR DESCRIPTION
### Resolves Sprint:

<!--- Link to sprint ticket --->
<!--- e.g. "[TICKET-001](https://kanban.example.com/tickets/TICKET-001)" --->

N/A

### This PR...

<!--- Short description of the overall change --->
<!--- e.g. "Adds hero section on homescreen" --->

Adds Settings screen and section.

### Changes:

<!--- Bullet points of changes made --->

- fix styling issue on Login inputfields
- add SettingsHeader component at `/screens/_components`

### Notes:

<!--- Any extra notes --->
<!--- e.g. how to test, links to relevant GitHub actions, follow-up tasks, etc. --->

N/A

### Screenshots:

<!--- Screenshots if relevant --->

<img width="225" height="500" alt="Screenshot_1756962754" src="https://github.com/user-attachments/assets/20af010f-ef5a-4626-9449-fcba485680e4" />

---

#### Check list:

- [ ] Sprint ticket met/completed
- [ ] Visual design aligned with design system
- [ ] A11y pass
- [ ] Built and run locally across all platforms, ensure no build or runtime errors/warnings
- [ ] Cross-browser/device testing
- [ ] No console errors
- [ ] Unit/functional tests are written; Or a manual test is planned
- [ ] Storybook component added and documented
- [ ] Config added/updated
- [ ] Updated `README.md`/docs to reflect changes
- [ ] Updated `.env.sample`
